### PR TITLE
Removed trailing slash from CORS_ALLOWED_ORIGINS client url

### DIFF
--- a/recipe_project/settings.py
+++ b/recipe_project/settings.py
@@ -54,7 +54,7 @@ CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:3000",
     "http://localhost:5173",
     "http://127.0.0.1:5173",
-    "https://recipe-client-lshi3.ondigitalocean.app/",
+    "https://recipe-client-lshi3.ondigitalocean.app",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
# Description

Removed trailing slash from CORS_ALLOWED_ORIGINS client url

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New feature

